### PR TITLE
Add Appveyor (CI) integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,7 @@ before_deploy:
       
       @(
           # You can add other artifacts here
-          $zipFilePath,
-          $nuGetPackagePath
+          $zipFilePath
       ) | % { 
           Write-Host "Pushing package $_ as Appveyor artifact"
           Push-AppveyorArtifact $_

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+#---------------------------------# 
+#      environment configuration  # 
+#---------------------------------# 
+version: 1.1.0.{build}
+install: 
+  - cinst -y pester
+
+#---------------------------------# 
+#      build configuration        # 
+#---------------------------------# 
+
+build: false
+
+#---------------------------------# 
+#      test configuration         # 
+#---------------------------------# 
+
+test_script:
+    - ps: |
+        $testResultsFile = ".\TestsResults.xml"
+        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+        (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+        if ($res.FailedCount -gt 0) { 
+            throw "$($res.FailedCount) tests failed."
+        }
+    
+#---------------------------------# 
+#      deployment configuration   # 
+#---------------------------------# 
+
+# scripts to run before deployment 
+before_deploy: 
+  - ps: |
+      # Creating project artifact
+      $stagingDirectory = (Resolve-Path ..).Path
+      $manifest = Join-Path $pwd "poke.psd1"
+      (Get-Content $manifest -Raw).Replace("1.1.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
+      $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
+      Add-Type -assemblyname System.IO.Compression.FileSystem
+      [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
+      
+      @(
+          # You can add other artifacts here
+          $zipFilePath,
+          $nuGetPackagePath
+      ) | % { 
+          Write-Host "Pushing package $_ as Appveyor artifact"
+          Push-AppveyorArtifact $_
+        }
+        
+        
+

--- a/poke.psd1
+++ b/poke.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Poke.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.2'
+ModuleVersion = '1.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'cba2bd6c-5303-479e-bbed-6fd997ea5d31'


### PR DESCRIPTION
Features
1) Auto-builds for all commits
2) Run pester tests and report results as nunit tests
3) Zip package as an artifact with unique version of the package (format 1.1.0.{build-number})

You can checkout a demo that I setup from my fork https://ci.appveyor.com/project/vors/poke/history

To enable it on the main repo, do the following:
1) sign up for a free account on ci.appveyor.com with your github account.
2) Add poke project from github (you would need to authorize appveyor application to access your public github data)
3) trigger a new build with a dummy branch (should contain appveyor.yml) to test it out

Let me know if you have any problems with appveyor.
They registration process is the hardest part. :)
